### PR TITLE
Fix vpn status bug

### DIFF
--- a/src/helpers.sh
+++ b/src/helpers.sh
@@ -153,7 +153,7 @@ getVPN() {
 
 # $1 = `scutil --nc list` lines
 getVPNInfo() {
-  if [[ "$1" =~ \*[[:space:]]\((.*)\)[[:space:]].*\"(.*)\".*\[(.*)\] ]]
+  if [[ "$1" =~ \*[[:space:]]\(([a-zA-Z ]*)\)[[:space:]].*\"(.*)\".*\[(.*)\] ]]
   then
     STATE=${BASH_REMATCH[1]}
     NAME=${BASH_REMATCH[2]}

--- a/tests/vpnTests.bats
+++ b/tests/vpnTests.bats
@@ -41,3 +41,16 @@ load variables
   [ "${ARRAY[2]}" == "PPP:L2TP" ]
   [ "${ARRAY[3]}" == "$ICON_VPN" ]
 }
+
+@test "getVPNInfo: get connected vpn info with paranthesis" {
+  INPUT="* (Connected)   65F5A799-4C98-4DA1-87D7-9D605D9D666C IPSec (com.vpn.vpn)              \"Another: VPN\"                            [IPSec]"
+
+  run getVPNInfo "$INPUT"
+  IFS='~' read -r -a ARRAY <<< "$output"
+
+  [ "$status" -eq 0 ]
+  [ "${ARRAY[0]}" == "Connected" ]
+  [ "${ARRAY[1]}" == "Another: VPN" ]
+  [ "${ARRAY[2]}" == "IPSec" ]
+  [ "${ARRAY[3]}" == "$ICON_VPN_CONNECTED" ]
+}


### PR DESCRIPTION
The status of VPN wasn't matched correctly if the name contained paranthesis.