### PR TITLE
Removing OneUpdater for Alfred Gallery

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -22,18 +22,7 @@
 			</dict>
 		</array>
 		<key>306C666D-40A5-42F2-A4A0-776B168E7799</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
+		<array/>
 		<key>328256C3-89CB-4454-91D1-8A35107A23EB</key>
 		<array>
 			<dict>
@@ -72,30 +61,9 @@
 				<key>vitoclose</key>
 				<false/>
 			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
 		</array>
 		<key>82D72C1A-0B33-483F-AA5E-E25B02CC7971</key>
-		<array>
-			<dict>
-				<key>destinationuid</key>
-				<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-		</array>
+		<array/>
 		<key>C416DACE-0F76-4BF9-A84C-D9B5497B1B00</key>
 		<array>
 			<dict>
@@ -114,16 +82,6 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>E675530B-3605-4460-8074-3122E0461D9D</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -150,16 +108,6 @@
 			<dict>
 				<key>destinationuid</key>
 				<string>E675530B-3605-4460-8074-3122E0461D9D</string>
-				<key>modifiers</key>
-				<integer>0</integer>
-				<key>modifiersubtext</key>
-				<string></string>
-				<key>vitoclose</key>
-				<false/>
-			</dict>
-			<dict>
-				<key>destinationuid</key>
-				<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
 				<key>modifiers</key>
 				<integer>0</integer>
 				<key>modifiersubtext</key>
@@ -362,97 +310,6 @@
 			<string>alfred.workflow.action.script</string>
 			<key>uid</key>
 			<string>C8DB69EA-BBA7-41E9-B60C-CF315A5F1CAD</string>
-			<key>version</key>
-			<integer>2</integer>
-		</dict>
-		<dict>
-			<key>config</key>
-			<dict>
-				<key>concurrently</key>
-				<false/>
-				<key>escaping</key>
-				<integer>0</integer>
-				<key>script</key>
-				<string># THESE VARIABLES MUST BE SET. SEE THE ONEUPDATER README FOR AN EXPLANATION OF EACH.
-readonly remote_info_plist='https://raw.githubusercontent.com/mrodalgaard/alfred-network-workflow/master/info.plist'
-readonly workflow_url='mrodalgaard/alfred-network-workflow'
-readonly download_type='github_release'
-readonly frequency_check='4'
-
-# FROM HERE ON, CODE SHOULD BE LEFT UNTOUCHED!
-function abort {
-  echo "${1}" &gt;&amp;2
-  exit 1
-}
-
-function url_exists {
-  curl --silent --location --output /dev/null --fail --range 0-0 "${1}"
-}
-
-function notification {
-  local -r notificator="$(find . -type d -name 'Notificator.app')"
-  if [[ -n "${notificator}" ]]; then
-    "${notificator}/Contents/Resources/Scripts/notificator" --message "${1}" --title "${alfred_workflow_name}" --subtitle 'A new version is available'
-    return
-  fi
-
-  local -r terminal_notifier="$(find . -type f -name 'terminal-notifier')"
-  if [[ -n "${terminal_notifier}" ]]; then
-    "${terminal_notifier}" -title "${alfred_workflow_name}" -subtitle 'A new version is available' -message "${1}"
-    return
-  fi
-
-  osascript -e "display notification \"${1}\" with title \"${alfred_workflow_name}\" subtitle \"A new version is available\""
-}
-
-# Local sanity checks
-readonly local_info_plist='info.plist'
-readonly local_version="$(/usr/libexec/PlistBuddy -c 'print version' "${local_info_plist}")"
-
-[[ -n "${local_version}" ]] || abort 'You need to set a workflow version in the configuration sheet.'
-[[ "${download_type}" =~ ^(direct|page|github_release)$ ]] || abort "'download_type' (${download_type}) needs to be one of 'direct', 'page', or 'github_release'."
-[[ "${frequency_check}" =~ ^[0-9]+$ ]] || abort "'frequency_check' (${frequency_check}) needs to be a number."
-
-# Check for updates
-if [[ $(find "${local_info_plist}" -mtime +"${frequency_check}"d) ]]; then
-  if ! url_exists "${remote_info_plist}"; then abort "'remote_info_plist' (${remote_info_plist}) appears to not be reachable."; fi # Remote sanity check
-
-  readonly tmp_file="$(mktemp)"
-  curl --silent --location --output "${tmp_file}" "${remote_info_plist}"
-  readonly remote_version="$(/usr/libexec/PlistBuddy -c 'print version' "${tmp_file}")"
-
-  if [[ "${local_version}" == "${remote_version}" ]]; then
-    touch "${local_info_plist}" # Reset timer by touching local file
-    exit 0
-  fi
-
-  if [[ "${download_type}" == 'page' ]]; then
-    notification 'Opening download page…'
-    open "${workflow_url}"
-    exit 0
-  fi
-
-  download_url="$([[ "${download_type}" == 'github_release' ]] &amp;&amp; curl --silent "https://api.github.com/repos/${workflow_url}/releases/latest" | grep 'browser_download_url' | head -1 | sed -E 's/.*browser_download_url": "(.*)"/\1/' || echo "${workflow_url}")"
-
-  if url_exists "${download_url}"; then
-    notification 'Downloading and installing…'
-    curl --silent --location --output "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow" "${download_url}"
-    open "${HOME}/Downloads/${alfred_workflow_name}.alfredworkflow"
-  else
-    abort "'workflow_url' (${download_url}) appears to not be reachable."
-  fi
-fi</string>
-				<key>scriptargtype</key>
-				<integer>1</integer>
-				<key>scriptfile</key>
-				<string></string>
-				<key>type</key>
-				<integer>0</integer>
-			</dict>
-			<key>type</key>
-			<string>alfred.workflow.action.script</string>
-			<key>uid</key>
-			<string>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</string>
 			<key>version</key>
 			<integer>2</integer>
 		</dict>
@@ -668,96 +525,83 @@ fi</string>
 		<key>18344CF4-87B8-4EAC-960F-0424188DBD78</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<real>30</real>
 			<key>ypos</key>
-			<integer>140</integer>
+			<real>140</real>
 		</dict>
 		<key>306C666D-40A5-42F2-A4A0-776B168E7799</key>
 		<dict>
 			<key>xpos</key>
-			<integer>230</integer>
+			<real>230</real>
 			<key>ypos</key>
-			<integer>380</integer>
+			<real>380</real>
 		</dict>
 		<key>328256C3-89CB-4454-91D1-8A35107A23EB</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<real>30</real>
 			<key>ypos</key>
-			<integer>20</integer>
+			<real>20</real>
 		</dict>
 		<key>4C74C452-E821-4F45-9B74-F0C28889BA4F</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<real>30</real>
 			<key>ypos</key>
-			<integer>260</integer>
+			<real>260</real>
 		</dict>
 		<key>709DCCB5-61D3-4693-8C39-F0A34FA8F6AD</key>
 		<dict>
 			<key>xpos</key>
-			<integer>230</integer>
+			<real>230</real>
 			<key>ypos</key>
-			<integer>140</integer>
+			<real>140</real>
 		</dict>
 		<key>82D72C1A-0B33-483F-AA5E-E25B02CC7971</key>
 		<dict>
 			<key>xpos</key>
-			<integer>230</integer>
+			<real>230</real>
 			<key>ypos</key>
-			<integer>500</integer>
+			<real>500</real>
 		</dict>
 		<key>C416DACE-0F76-4BF9-A84C-D9B5497B1B00</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<real>30</real>
 			<key>ypos</key>
-			<integer>380</integer>
+			<real>380</real>
 		</dict>
 		<key>C8DB69EA-BBA7-41E9-B60C-CF315A5F1CAD</key>
 		<dict>
 			<key>xpos</key>
-			<integer>230</integer>
+			<real>230</real>
 			<key>ypos</key>
-			<integer>260</integer>
+			<real>260</real>
 		</dict>
 		<key>D4820948-B40E-4B36-BD86-21E6BFDB7FF8</key>
 		<dict>
 			<key>xpos</key>
-			<integer>30</integer>
+			<real>30</real>
 			<key>ypos</key>
-			<integer>500</integer>
-		</dict>
-		<key>E0BFD45D-AC9A-462F-AA9E-BB57F1B518C7</key>
-		<dict>
-			<key>colorindex</key>
-			<integer>12</integer>
-			<key>note</key>
-			<string>OneUpdater</string>
-			<key>xpos</key>
-			<integer>510</integer>
-			<key>ypos</key>
-			<integer>260</integer>
+			<real>500</real>
 		</dict>
 		<key>E675530B-3605-4460-8074-3122E0461D9D</key>
 		<dict>
 			<key>xpos</key>
-			<integer>510</integer>
+			<real>510</real>
 			<key>ypos</key>
-			<integer>20</integer>
+			<real>20</real>
 		</dict>
 		<key>E94FF980-5C9E-41B4-862B-30C04F904070</key>
 		<dict>
 			<key>xpos</key>
-			<integer>230</integer>
+			<real>230</real>
 			<key>ypos</key>
-			<integer>20</integer>
+			<real>20</real>
 		</dict>
 	</dict>
-	<key>variablesdontexport</key>
-	<array/>
 	<key>version</key>
-	<string>1.5</string>
+	<string>1.6</string>
 	<key>webaddress</key>
 	<string>https://github.com/mrodalgaard/alfred-network-workflow</string>
 </dict>


### PR DESCRIPTION
When [the Alfred Gallery](https://www.alfredforum.com/topic/19058-submitting-workflows-for-the-alfred-gallery/) is live, added workflows will be updatable from within Alfred itself. As part of that, a prerequisite for inclusion will be that workflows *not* auto-update themselves. This is to avoid a confusing interaction of crossed updates *and* for security reasons, as Gallery workflows go through a number of checks.

Your development process won’t change. You’ll still make GitHub releases as usual to update the workflow. We’ll detect when new releases are out and queue them up for a new review and update in the Gallery.

This PR removes OneUpdater (and updates the info.plist, as it seems the file in the repo was behind the release). Merging it now and making a new release helps to speed up the process, but if you prefer to wait I’ll ping you again once the Gallery is live. It’s also fine if you prefer to close the PR and do the change yourself.